### PR TITLE
[Hyperswitch] Throw 4xx in case of recieving webhooks for payments not processed via saleor

### DIFF
--- a/src/modules/hyperswitch/hyperswitch-api-response.ts
+++ b/src/modules/hyperswitch/hyperswitch-api-response.ts
@@ -2,8 +2,8 @@ import { z, ZodError } from "zod";
 import { JsonSchemaError } from "@/errors";
 
 export const SaleorMetadataSchema = z.object({
-  transaction_id: z.string(),
-  saleor_api_url: z.string(),
+  transaction_id: z.string().nullable().optional(),
+  saleor_api_url: z.string().nullable().optional(),
 });
 
 export const PaymentLinkSchema = z.object({
@@ -98,7 +98,7 @@ const WebhookObjectBodySchema = z.object({
   status: z.string(),
   payment_id: z.string(),
   refund_id: z.string().nullable().optional(),
-  metadata: SaleorMetadataSchema,
+  metadata: SaleorMetadataSchema.nullable().optional(),
   capture_method: CaptureMethodEnum.nullable().optional(),
   error_message: z.string().nullable().optional(),
 });

--- a/src/pages/api/webhooks/hyperswitch/authorization.ts
+++ b/src/pages/api/webhooks/hyperswitch/authorization.ts
@@ -132,7 +132,7 @@ export default async function hyperswitchAuthorizationWebhookHandler(
     });
     const payment_id = webhookBody.content.object.payment_id;
     const refund_id = webhookBody.content.object.refund_id;
-    
+
     if (
       !(
         webhookBody.content?.object?.metadata &&
@@ -140,11 +140,10 @@ export default async function hyperswitchAuthorizationWebhookHandler(
         webhookBody.content.object.metadata.saleor_api_url
       )
     ) {
-      const message = "Recieved webhook for a payment, not done via Saleor Hyperswitch Plugin";
+      const message = "Recieved webhook for a payment, processed via Saleor Hyperswitch Plugin";
       logger.info(`${payment_id}: ${message}`);
       return res.status(400).json(message);
     }
-    
 
     const transactionId = webhookBody.content.object.metadata.transaction_id;
     const saleorApiUrl = webhookBody.content.object.metadata.saleor_api_url;
@@ -260,9 +259,7 @@ export default async function hyperswitchAuthorizationWebhookHandler(
 
     res.status(200).json("[OK]");
   } catch (error) {
-    logger.info({message: `Deserialization Error ${error}`,
-    payload : req.body
-  });
+    logger.info({ message: `Deserialization Error ${error}`, payload: req.body });
     res.status(500).json("Deserialization Error");
   }
 }

--- a/src/pages/api/webhooks/juspay/authorization.ts
+++ b/src/pages/api/webhooks/juspay/authorization.ts
@@ -316,7 +316,9 @@ export default async function juspayAuthorizationWebhookHandler(
     logger.info("Updated status successfully");
     res.status(200).json("[OK]");
   } catch (error) {
-    logger.info(`Deserialization Error: ${error} \n Juspay Webhook body: ${req.body}`);
+    logger.info({message: `Deserialization Error ${error}`,
+    payload : req.body
+  });;
     res.status(500).json("Deserialization Error");
   }
 }

--- a/src/pages/api/webhooks/juspay/authorization.ts
+++ b/src/pages/api/webhooks/juspay/authorization.ts
@@ -316,9 +316,7 @@ export default async function juspayAuthorizationWebhookHandler(
     logger.info("Updated status successfully");
     res.status(200).json("[OK]");
   } catch (error) {
-    logger.info({message: `Deserialization Error ${error}`,
-    payload : req.body
-  });;
+    logger.info({ message: `Deserialization Error ${error}`, payload: req.body });
     res.status(500).json("Deserialization Error");
   }
 }


### PR DESCRIPTION
Previously, when receiving webhooks from Hyperswitch for payments that were not processed through Saleor, we returned a 5xx error. This PR addresses the issue by changing the response to a 400 status code with a clear error message