### PR TITLE
fix: typos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-SECRET_KEY=your_secert_key #mandatory
+SECRET_KEY=your_secret_key #mandatory
 APP_DEBUG= #possible values "fatal", "error", "warn", "info", "debug", "trace", "silent" 
            #optional, default: error
-APL = # possible values upstash[multi-tenant], file [single-tenant]
+APL= # possible values upstash[multi-tenant], file [single-tenant]
       # optional, default file
-UPSTASH_URL =  # required if APL is upstash
-UPSTASH_TOKEN = # required if APL is upstash
-HYPERSWITCH_PROD_BASE_URL = # hyperswitch prod server url
-HYPERSWITCH_SANDBOX_BASE_URL =  # hyperswitch testing server url
+UPSTASH_URL=  # required if APL is upstash
+UPSTASH_TOKEN= # required if APL is upstash
+HYPERSWITCH_PROD_BASE_URL= # hyperswitch prod server url
+HYPERSWITCH_SANDBOX_BASE_URL=  # hyperswitch testing server url
 JUSPAY_SANDBOX_BASE_URL= # juspay testing server url
 JUSPAY_PROD_BASE_URL= # juspay prod server url

--- a/src/backend-lib/api-route-utils.ts
+++ b/src/backend-lib/api-route-utils.ts
@@ -63,7 +63,7 @@ export function getSyncWebhookHandler<TPayload, TResult, TSchema extends Validat
       const configData = await configHandler(payload, authData.saleorApiUrl);
       const orchestra = await getOrchestra(configData);
       const result =
-        orchestra == Orchersta.Juspay
+        orchestra == Orchestra.Juspay
           ? await webhookHandlerJuspay(payload, authData.saleorApiUrl, configData)
           : await webhookHandlerHyperswitch(payload, authData.saleorApiUrl, configData);
 
@@ -145,7 +145,7 @@ export const getAuthDataForRequest = async (request: NextApiRequest) => {
   return authData;
 };
 
-enum Orchersta {
+enum Orchestra {
   Hyperswitch,
   Juspay,
 }
@@ -155,13 +155,13 @@ export type ConfigObject = {
   channelId: string;
 };
 
-async function getOrchestra<TPayload>(configData: ConfigObject): Promise<Error | Orchersta> {
+async function getOrchestra<TPayload>(configData: ConfigObject): Promise<Error | Orchestra> {
   const appConfig = await configData.configurator.getConfig();
   const appChannelConfig = getConfigurationForChannel(appConfig, configData.channelId);
   const config = paymentAppFullyConfiguredEntrySchema.parse(appChannelConfig);
   if (config.juspayConfiguration) {
-    return Orchersta.Juspay;
+    return Orchestra.Juspay;
   } else {
-    return Orchersta.Hyperswitch;
+    return Orchestra.Hyperswitch;
   }
 }


### PR DESCRIPTION
Fix some code typos (`Orchersta` -> `Orchestra`, `secert` -> `secret`,  spaces before `=` on a `.env` file )